### PR TITLE
Changed usage-message to be dynamic (using $0)

### DIFF
--- a/setupClient.sh
+++ b/setupClient.sh
@@ -5,7 +5,7 @@ if [ "$(id -u)" != "0" ]; then
    exit 1
 fi
 if [ -z $keyHost ] ; then
-	echo "usage: setupClient.sh user@keyserver"
+	echo "Usage: $0 user@keyserver"
 	exit 0
 fi
 echo "Setting up Key-Server at $1"


### PR DESCRIPTION
See commit. Using $0 is more dynamic than using a static filename.